### PR TITLE
feat(doom): Add `icon_offset` to entry menu options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ config = {
     {
       icon = '',
       icon_hl = 'group',
+      icon_offset = 0, -- Use for non-standard width glyphs to fix the cursor column position at the menu entry
       desc = 'description',
       desc_hl = 'group',
       key = 'shortcut key in dashboard buffer not keymap !!',

--- a/lua/dashboard/theme/doom.lua
+++ b/lua/dashboard/theme/doom.lua
@@ -9,7 +9,8 @@ local function generate_center(config)
     }
 
   local counts = {}
-  for _, item in pairs(center) do
+  local icons_offsets = {}
+  for item_idx, item in pairs(center) do
     local count = item.keymap and #item.keymap or 0
     local line = (item.icon or '') .. item.desc
 
@@ -39,6 +40,10 @@ local function generate_center(config)
       line = line .. (' '):rep(#item.keymap)
     end
 
+    if item.icon_offset then
+      table.insert(icons_offsets, { item_idx * 2 - 1, item.icon_offset })
+    end
+
     table.insert(lines, line)
     table.insert(lines, '')
     table.insert(counts, count)
@@ -56,6 +61,11 @@ local function generate_center(config)
 
   if not config.center then
     return
+  end
+
+  local col_offsets = {}
+  for _, offset in pairs(icons_offsets) do
+    col_offsets[offset[1] + first_line] = offset[2]
   end
 
   local ns = api.nvim_create_namespace('DashboardDoom')
@@ -129,7 +139,11 @@ local function generate_center(config)
           curline = curline + (before > curline and -1 or 1)
         end
         before = curline
-        api.nvim_win_set_cursor(config.winid, { curline, col })
+        if not col_offsets[curline] then
+          api.nvim_win_set_cursor(config.winid, { curline, col })
+        else
+          api.nvim_win_set_cursor(config.winid, { curline, col + col_offsets[curline] })
+        end
       end,
     })
   end, 0)


### PR DESCRIPTION
This should allow the user to add an indentation offset in cases where a font icon causes the cursor position not to align correctly with the first character of the menu description.